### PR TITLE
Respect pre-existing CFLAGS and LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PNAME=smallfry
 CC = gcc
-CFLAGS=-Wall
-LDFLAGS=-s
+CFLAGS+=-O3 -Wall
+LDFLAGS+=-s
 LIBS=-lm
 ARC = ar rcs
 LN = @ln -fsv


### PR DESCRIPTION
Avoid overwriting pre-existing CFLAGS and LDFLAGS by using `+=` instead of `=`.  Use `-O3` optimization when building.